### PR TITLE
PHP 5.3.0 deprecates import_request_variables

### DIFF
--- a/netskeldb.php
+++ b/netskeldb.php
@@ -2,7 +2,7 @@
 
   include "init.inc";
 
-  import_request_variables("cpg","rvar_");
+  extract($_REQUEST, EXTR_PREFIX_ALL|EXTR_REFS, 'rvar');
 
   header('Cache-Control: max-age=0, must-revalidate, no-cache, no-store');
   header('Content-Type: text/plain');


### PR DESCRIPTION
extract() gives similar functionality, allowing the script to continue to work on 5.3.0 and above.
