### PR TITLE
Compatibility with PHP 5.4

### DIFF
--- a/getclient.php
+++ b/getclient.php
@@ -2,7 +2,6 @@
 
   include "init.inc";
 
-  #import_request_variables("cpg","rvar_");
   extract($_REQUEST, EXTR_PREFIX_ALL|EXTR_REFS, 'rvar');
 
 

--- a/getclient.php
+++ b/getclient.php
@@ -2,7 +2,9 @@
 
   include "init.inc";
 
-  import_request_variables("cpg","rvar_");
+  #import_request_variables("cpg","rvar_");
+  extract($_REQUEST, EXTR_PREFIX_ALL|EXTR_REFS, 'rvar');
+
 
   header('Cache-Control: max-age=0, must-revalidate, no-cache, no-store');
   header('Content-Type: text/plain');

--- a/netskeldb.php
+++ b/netskeldb.php
@@ -2,7 +2,6 @@
 
   include "init.inc";
 
-  #import_request_variables("cpg","rvar_");
   extract($_REQUEST, EXTR_PREFIX_ALL|EXTR_REFS, 'rvar');
 
   header('Cache-Control: max-age=0, must-revalidate, no-cache, no-store');

--- a/netskeldb.php
+++ b/netskeldb.php
@@ -2,7 +2,8 @@
 
   include "init.inc";
 
-  import_request_variables("cpg","rvar_");
+  #import_request_variables("cpg","rvar_");
+  extract($_REQUEST, EXTR_PREFIX_ALL|EXTR_REFS, 'rvar');
 
   header('Cache-Control: max-age=0, must-revalidate, no-cache, no-store');
   header('Content-Type: text/plain');

--- a/sendfile.php
+++ b/sendfile.php
@@ -2,7 +2,6 @@
 
   include "init.inc";
 
-  #import_request_variables("cpg","rvar_");
   extract($_REQUEST, EXTR_PREFIX_ALL|EXTR_REFS, 'rvar');
 
   header('Cache-Control: max-age=0, must-revalidate, no-cache, no-store');

--- a/sendfile.php
+++ b/sendfile.php
@@ -2,7 +2,8 @@
 
   include "init.inc";
 
-  import_request_variables("cpg","rvar_");
+  #import_request_variables("cpg","rvar_");
+  extract($_REQUEST, EXTR_PREFIX_ALL|EXTR_REFS, 'rvar');
 
   header('Cache-Control: max-age=0, must-revalidate, no-cache, no-store');
   header('Content-Type: text/plain');


### PR DESCRIPTION
PHP 5.4 pulled the import_request_variables function. I replaced it with extract().
