### PR TITLE
Migrate away from abandoned uuid library

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/blackjack/syslog"
 	"github.com/boltdb/bolt"
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"golang.org/x/crypto/ssh"
 )
 


### PR DESCRIPTION
github.com/satori/go.uuid seems abandoned and a fork at github.com/gofrs/uuid is actively being developed and improved.  This is a drop-in replacement.